### PR TITLE
Use pep8 instead of flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
 
 install:
   - pip install -r requirements.txt
-  - pip install flake8
+  - pip install pep8
 
 script:
-  - flake8 --ignore=E501 .
+  - pep8 --ignore=E501 .


### PR DESCRIPTION
Caused by flake8 errors with python2.6

Signed-off-by: JetMuffin 564936642@qq.com
